### PR TITLE
Reg 56 use dart image in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ before_install:
 
 install:
   # Travis specific install
-  #- sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-  #- sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-  #- sudo apt-get update
-  #- sudo apt-get install dart
-  #- export PATH=$PATH:/usr/lib/dart/bin
   # Install Dartium
   - wget https://storage.googleapis.com/dart-archive/channels/stable/release/latest/dartium/dartium-linux-x64-release.zip
   - unzip dartium-linux-x64-release.zip
@@ -43,13 +38,11 @@ script:
   # necessary for webdriver to become available
   # - sleep 3 && echo sleep done
   #- (cd e2e_tests && make tests)
+  - (cd frontend && cat angular-server.log)
+  #- (cd e2e_tests && cat webdriver.log)
 
 after_success:
   - (cd frontend && make build)
-
-after_script:
-  - (cd frontend && cat angular-server.log)
-  #- (cd e2e_tests && cat webdriver.log)
 
 before_deploy:
   - (cd functions && npm install)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 sudo: required
 dist: trusty
 
-language: python
-
-python:
-  - "3.4"
+language: dart
 
 before_install:
   # 2 lines of workaround as proposed here: https://github.com/travis-ci/travis-ci/issues/6928#issuecomment-264227708
@@ -13,12 +10,14 @@ before_install:
 
 install:
   # Travis specific install
-  - sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-  - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-  - sudo apt-get update
-  - sudo apt-get install dart
-  - export PATH=$PATH:/usr/lib/dart/bin
+  #- sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+  #- sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+  #- sudo apt-get update
+  #- sudo apt-get install dart
+  #- export PATH=$PATH:/usr/lib/dart/bin
   # Install Dartium
+  - which chrome
+  - which dartium
   - wget https://storage.googleapis.com/dart-archive/channels/stable/release/latest/dartium/dartium-linux-x64-release.zip
   - unzip dartium-linux-x64-release.zip
   - rm dartium-linux-x64-release.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ install:
   #- sudo apt-get install dart
   #- export PATH=$PATH:/usr/lib/dart/bin
   # Install Dartium
-  - which chrome
-  - which dartium
   - wget https://storage.googleapis.com/dart-archive/channels/stable/release/latest/dartium/dartium-linux-x64-release.zip
   - unzip dartium-linux-x64-release.zip
   - rm dartium-linux-x64-release.zip


### PR DESCRIPTION
Since we are no longer using any python, switch to the dart travis image.